### PR TITLE
Update to the last d.py version, update to new thread perms.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/Rapptz/discord.py@58ca9e99325ac2678a51cd63afd7ae917f14bc8d
+git+git://github.com/Rapptz/discord.py@45d498c1b76deaf3b394d17ccf56112fa691d160
 black==20.8b1
 aiohttp>=3.6.0,<3.7.0
 beautifulsoup4==4.9.3

--- a/src/cogs/CourseThreads.py
+++ b/src/cogs/CourseThreads.py
@@ -76,8 +76,10 @@ class CourseThreads(commands.Cog):
         await channel.set_permissions(
             ctx.guild.default_role,
             send_messages=False,
-            use_private_threads=False,
-            use_threads=True,
+            create_public_threads=False,
+            create_private_threads=False,
+            send_messages_in_threads=True,
+            manage_threads=False,
         )
         self.course_mappings[year_level] = {
             BASE_CHANNEL_KEY: channel.id,


### PR DESCRIPTION
[Thread permissions are changing](https://support.discord.com/hc/en-us/articles/4404809613847). This updates to the new permissions.

I was also considering adding support for multi-tenancy (currently this cog only supports one server with regards to course threads), but the future of discord.py is uncertain as [it's been deprecated](https://gist.github.com/Rapptz/4a2f62751b9600a31a0d3c78100287f1). Probably something to keep in mind as this means the bot will probably break eventually without upstream support.