### PR TITLE
Some small hotfixes for perms and threads.

### DIFF
--- a/src/cogs/CourseThreads.py
+++ b/src/cogs/CourseThreads.py
@@ -111,7 +111,7 @@ class CourseThreads(commands.Cog):
             base_message: discord.Message = await base_channel.send(
                 f"Thread for `{course}`"
             )
-            created_thread: discord.Thread = await base_message.start_thread(
+            created_thread: discord.Thread = await base_message.create_thread(
                 name=str(course)
             )
             self.course_mappings[course.year_level][CURRENT_COURSES_KEY][

--- a/src/utils/Checks.py
+++ b/src/utils/Checks.py
@@ -2,9 +2,8 @@ import discord
 from discord.ext import commands
 
 
-def ban_members_check(ctx: commands.Context):
-    return (
-        ctx.bot.is_owner(ctx.author)
-        or isinstance(ctx.author, discord.Member)
+async def ban_members_check(ctx: commands.Context):
+    return await ctx.bot.is_owner(ctx.author) or (
+        isinstance(ctx.author, discord.Member)
         and ctx.author.guild_permissions.ban_members
     )


### PR DESCRIPTION
- Rename `start_thread` method to `create_thread` as per [this commit](https://github.com/Rapptz/discord.py/commit/1e17b7fceaf7173b1666465e639d1bebaa126683)
- Fix permissions for `ban_members_check`

That last one is interesting since the check expects a coroutine, and it just so happens that the first boolean returns a coroutine, resulting in a truthy evaluation so it short circuits and returns that coroutine; it never ends up checking the rest of the predicate.

What a neat bug.